### PR TITLE
Develop

### DIFF
--- a/git-ninja.sh
+++ b/git-ninja.sh
@@ -142,7 +142,7 @@ fi
 read -p "⬆️  Push changes to remote? (y/n) [y]: " push_changes
 push_changes=${push_changes:-y}
 if [[ "$push_changes" == "y" ]]; then
-    start_loading "Pushing changes to remote.."
+    start_loading "Pushing changes to remote..."
     git push
 else
     echo -e "${RED}❌ Push cancelled.${RESET}"

--- a/git-ninja.sh
+++ b/git-ninja.sh
@@ -139,6 +139,21 @@ if [[ -n "$tag" ]]; then
     echo -e "${GREEN}✅ Tag '${BOLD}$tag${RESET}${GREEN}' added to commit.${RESET}"
 fi
 
+check_upstream() {
+    current_branch=$(git rev-parse --abbrev-ref HEAD)
+    upstream=$(git rev-parse --abbrev-ref "$current_branch@{u}" 2>/dev/null)
+    
+    if [ -z "$upstream" ]; then
+        echo -e "${YELLOW}⚠️  No upstream branch found for ${current_branch}.${RESET}"
+        echo -e "${CYAN}Setting upstream to origin/${current_branch}.${RESET}"
+        git push --set-upstream origin "$current_branch"
+    else
+        echo -e "${GREEN}✔ Upstream branch is already set for ${current_branch}.${RESET}"
+    fi
+}
+
+check_upstream
+
 read -p "⬆️  Push changes to remote? (y/n) [y]: " push_changes
 push_changes=${push_changes:-y}
 if [[ "$push_changes" == "y" ]]; then


### PR DESCRIPTION
This pull request includes an enhancement to the `git-ninja.sh` script to ensure that the current branch has an upstream branch set before pushing changes. The most important changes include adding a new function to check and set the upstream branch if it is not already set.

Enhancements to `git-ninja.sh`:

* Added the `check_upstream` function to verify if the current branch has an upstream branch set, and if not, set it to `origin/current_branch`.
* Called the `check_upstream` function before prompting the user to push changes to the remote.